### PR TITLE
feat: 権限がないユーザーはinfoコマンドを実行できないように

### DIFF
--- a/src/main/java/com/github/ucchyocean/lc3/Messages.java
+++ b/src/main/java/com/github/ucchyocean/lc3/Messages.java
@@ -1142,6 +1142,16 @@ public class Messages {
     }
 
     /**
+     * あなたが参加していないチャンネルの情報は確認できません。
+     */
+    public static String errmsgNotJoinMember() {
+        String msg = resources.getString("errmsgNotJoinMember");
+        if( msg == null ) return "";
+        KeywordReplacer kr = new KeywordReplacer(msg);
+        return Utility.replaceColorCode(resources.getString("errorPrefix", "") + kr.toString());
+    }
+
+    /**
      * 指定されたプレイヤー %player% が見つかりません。
      */
     public static String errmsgNotfoundPlayer(Object player) {

--- a/src/main/java/com/github/ucchyocean/lc3/command/InfoCommand.java
+++ b/src/main/java/com/github/ucchyocean/lc3/command/InfoCommand.java
@@ -106,7 +106,7 @@ public class InfoCommand extends LunaChatSubCommand {
         if( !channel.getPassword().equals("") ) {
             ChannelMember joined = ChannelMember.getChannelMemberFast(sender.getName());
             if ( !channel.getMembers().contains(joined) ) {
-                sender.sendMessage(Messages.errmsgNomemberOther());
+                sender.sendMessage(Messages.errmsgNotJoinMember());
                 return true;
             }
         }

--- a/src/main/java/com/github/ucchyocean/lc3/command/InfoCommand.java
+++ b/src/main/java/com/github/ucchyocean/lc3/command/InfoCommand.java
@@ -105,7 +105,7 @@ public class InfoCommand extends LunaChatSubCommand {
         // パスワード設定されているか確認する
         if( !channel.getPassword().equals("") ) {
             // 参加していない場合はコマンド処理を回帰する
-            ChannelMember joined = ChannelMember.getChannelMemberFast(sender.getName());
+            ChannelMember joined = ChannelMember.getChannelMember(sender.getName());
             if ( !channel.getMembers().contains(joined) ) {
                 sender.sendMessage(Messages.errmsgNotJoinMember());
                 return true;

--- a/src/main/java/com/github/ucchyocean/lc3/command/InfoCommand.java
+++ b/src/main/java/com/github/ucchyocean/lc3/command/InfoCommand.java
@@ -104,6 +104,7 @@ public class InfoCommand extends LunaChatSubCommand {
 
         // パスワード設定されているか確認する
         if( !channel.getPassword().equals("") ) {
+            // 参加していない場合はコマンド処理を回帰する
             ChannelMember joined = ChannelMember.getChannelMemberFast(sender.getName());
             if ( !channel.getMembers().contains(joined) ) {
                 sender.sendMessage(Messages.errmsgNotJoinMember());

--- a/src/main/java/com/github/ucchyocean/lc3/command/InfoCommand.java
+++ b/src/main/java/com/github/ucchyocean/lc3/command/InfoCommand.java
@@ -102,6 +102,15 @@ public class InfoCommand extends LunaChatSubCommand {
             return true;
         }
 
+        // パスワード設定されているか確認する
+        if( !channel.getPassword().equals("") ) {
+            ChannelMember joined = ChannelMember.getChannelMemberFast(sender.getName());
+            if ( !channel.getMembers().contains(joined) ) {
+                sender.sendMessage(Messages.errmsgNomemberOther());
+                return true;
+            }
+        }
+
         // チャンネルモデレーターかどうか確認する
         boolean isModerator = channel.hasModeratorPermission(sender);
 

--- a/src/main/resources/messages_en.yml
+++ b/src/main/resources/messages_en.yml
@@ -108,6 +108,7 @@ errmsgNotExistOrNotSpecified: 'Either the specified channel does not exist or th
 errmsgExist: 'The specified channel name already exists.'
 errmsgNomember: 'You have not joined the specified channel.'
 errmsgNomemberOther: 'The specified player has not joined the channel.'
+errmsgNotJoinMember: 'You will not be able to see information on channels in which you are not a participant.'
 errmsgNotfoundPlayer: 'The specified player %player% cannot be found.'
 errmsgNotInvited: 'You are not the invited player.'
 errmsgNotfoundChannel: 'You couldn''t join because the channels are gone.'

--- a/src/main/resources/messages_en.yml
+++ b/src/main/resources/messages_en.yml
@@ -108,7 +108,7 @@ errmsgNotExistOrNotSpecified: 'Either the specified channel does not exist or th
 errmsgExist: 'The specified channel name already exists.'
 errmsgNomember: 'You have not joined the specified channel.'
 errmsgNomemberOther: 'The specified player has not joined the channel.'
-errmsgNotJoinMember: 'You will not be able to see information on channels in which you are not a participant.'
+errmsgNotJoinMember: 'You can't see information on channels in which you are not a participant.'
 errmsgNotfoundPlayer: 'The specified player %player% cannot be found.'
 errmsgNotInvited: 'You are not the invited player.'
 errmsgNotfoundChannel: 'You couldn''t join because the channels are gone.'

--- a/src/main/resources/messages_ja.yml
+++ b/src/main/resources/messages_ja.yml
@@ -108,6 +108,7 @@ errmsgNotExistOrNotSpecified: '指定されたチャンネルが存在しない�
 errmsgExist: '指定されたチャンネル名が既に存在します。'
 errmsgNomember: '指定されたチャンネルに参加していません。'
 errmsgNomemberOther: '指定されたプレイヤーはチャンネルに参加していません。'
+errmsgNotJoinMember: 'あなたが参加していないチャンネルの情報は確認できません。'
 errmsgNotfoundPlayer: '指定されたプレイヤー %player% が見つかりません。'
 errmsgNotInvited: '招待を受けたプレイヤーではありません。'
 errmsgNotfoundChannel: 'チャンネルが無くなってしまったため、参加できませんでした。'


### PR DESCRIPTION
- パスワードが設定されていてそのチャンネルに参加していないユーザーがそのチャンネルに対しての `/ch info` を実行された場合、エラーで返すように